### PR TITLE
Add 2022 filter button

### DIFF
--- a/builds.html
+++ b/builds.html
@@ -341,6 +341,7 @@
                     <button class="btn btn-primary filter filterName" data-filtervalue="2016">2016</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="2017">2017</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="2019">2019</button>
+                    <button class="btn btn-primary filter filterName" data-filtervalue="2022">2022</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="">All</button>
                 </div>
                 <div class="btn-group btn-group-vertical hidden-xs-up" role="group">
@@ -353,6 +354,7 @@
                     <button class="btn btn-primary filter filterName" data-filtervalue="2016">2016</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="2017">2017</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="2019">2019</button>
+                    <button class="btn btn-primary filter filterName" data-filtervalue="2022">2022</button>
                     <button class="btn btn-primary filter filterName" data-filtervalue="">All</button>
                 </div>
             </div>


### PR DESCRIPTION
2022 shows up in the table but not in the filter:

![image](https://user-images.githubusercontent.com/981370/188402838-64e65a83-072b-421c-b269-ee905333cbc7.png)

Copied code for 2019 to add 2022 buttons